### PR TITLE
Mariadb with init container

### DIFF
--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -6,4 +6,6 @@ resources:
   - activemq_service.yaml
   - cantaloupe_deployment.yaml
   - cantaloupe_service.yaml
+  - mariadb_service.yaml
+  - mariadb_deployment.yaml
   

--- a/base/mariadb_deployment.yaml
+++ b/base/mariadb_deployment.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mariadb
+  labels:
+    app: mariadb
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mariadb
+  template:
+    metadata:
+      labels:
+        app: mariadb
+    spec:
+      containers:
+        - image: islandora/mariadb:latest
+          name: mariadb
+          imagePullPolicy: Always
+          volumeMounts:
+            - mountPath: /var/lib/mysql
+              name: mariadb-data
+            - mountPath: /var/lib/mysql-files
+              name: mariadb-files
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mariadb
+                  key: root_password
+          ports:
+            - containerPort: 3306
+      initContainers:
+        - image: ghcr.io/jhu-idc/mariadb/perms-init-container:latest
+          name: mariadb-init-data-perms
+          imagePullPolicy: Always
+          volumeMounts:
+            - mountPath: /var/lib/mysql
+              name: mariadb-data
+          env:
+            - name: MARIADB_INIT_DIRECTORY
+              value: /var/lib/mysql
+            - name: MARIADB_CHANGE_TO
+              value: "100:101"
+
+      volumes:
+        - name: mariadb-data
+          persistentVolumeClaim:
+            claimName: mariadb-data
+        - name: mariadb-files
+          persistentVolumeClaim:
+            claimName: mariadb-files

--- a/base/mariadb_service.yaml
+++ b/base/mariadb_service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mariadb
+spec:
+  selector:
+    app: mariadb
+  ports:
+    - protocol: TCP
+      port: 3306
+      name: mysql
+

--- a/overlays/development/linux/mariadb_pv.yaml
+++ b/overlays/development/linux/mariadb_pv.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: mariadb-data
+spec:
+  accessModes:
+    - ReadWriteMany
+  capacity:
+    storage: 1Gi
+  hostPath:
+    path: /minikube-host/idc/mariadb-data
+
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: mariadb-files
+spec:
+  accessModes:
+    - ReadWriteMany
+  capacity:
+    storage: 1Gi
+  hostPath:
+    path: /minikube-host/idc/mariadb-files

--- a/overlays/development/resources/kustomization.yaml
+++ b/overlays/development/resources/kustomization.yaml
@@ -5,3 +5,5 @@ resources:
   - ./activemq_pvc.yaml
   - ./activemq_secrets.yaml
   - ./cantaloupe_pvc.yaml
+  - ./mariadb_secrets.yaml
+  - ./mariadb_pvc.yaml

--- a/overlays/development/resources/mariadb_pvc.yaml
+++ b/overlays/development/resources/mariadb_pvc.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mariadb-data
+spec:
+  storageClassName: ""
+  volumeName: mariadb-data
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1G
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mariadb-files
+spec:
+  storageClassName: ""
+  volumeName: mariadb-files
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Gi

--- a/overlays/development/resources/mariadb_secrets.yaml
+++ b/overlays/development/resources/mariadb_secrets.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mariadb
+data:
+  root_password: bw9v


### PR DESCRIPTION
Converts mariadb from docker-compose to kubernetes resources

This utilizes a simple init container to ensure ownership of the mysql data directory is right.