### PR TITLE
Update images document snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,29 @@
 # idcApp-k8s
 Base application repository for the iDC kubernetes project.
 
+## Quick start
+
+1. Extract snapshot content into a tar file.  Currently, idcApp-k8s does not have a convenient way of handling snapshots, so this must be handled manually.
+
+   a. Identify a snapshot image to extract.  Copy the latest image tag from [the github package registry](https://github.com/orgs/jhu-sheridan-libraries/packages/container/package/idc-isle-dc%2Fsnapshot), or look in `idc-isle-dc/.env`.  For example, `ghcr.io/jhu-sheridan-libraries/idc-isle-dc/snapshot:upstream-20201007-739693ae-213-g3669e99.1616768917`.
+
+   b. Extract a tar file from the snapshot image via `snapshot=$(docker create <IMAGE>); docker export $snapshot > data.tar`.  For example,
+     <pre>
+      snapshot=$(docker create ghcr.io/jhu-sheridan-libraries/idc-isle-dc/snapshot:upstream-20201007-739693ae-213-g3669e99.1616768917); \
+      docker export $snapshot > data.tar
+     </pre>
+
+1. Extract the `data` directory of the tar file to the right location for your platform; then re-name it to `idc`.  _if there is a pre-existing `idc` directory present, delete it.  The kubernetes app uses this directory as a bind mount volume for all persistent state.  So deleting the existing idc directory and replacing it with content extracted from the snapshot will start from a clean/empty snapshot_.
+
+   a. Windows (wsl2):  `tar -C /mnt/c/kubernetes -xvf data.tar data;  mv /mnt/c/kubernetes/data /mnt/c/kubernetes/idc`
+
+   b. Linux:  `tar -C /minukube-host/ -xvf data.tar data;  mv /minikube-host/data /minikube-host/idc`
+
+   c. Mac:  ??
+
+1. `cd` into the overlays/development/&lt;PLATFORM&gt; directory for your platform.
+
+1. Run `kubectl kustomize . | kubectl apply -f -` to start the stack!
+
 ## Development
 To develop this application, clone https://github.com/jhu-sheridan-libraries/idc-kubernetes with recursion. This is a submodule of that repository. 

--- a/base/activemq_deployment.yaml
+++ b/base/activemq_deployment.yaml
@@ -15,7 +15,7 @@ spec:
         app: activemq
     spec:
       containers:
-        - image: islandora/activemq:latest
+        - image: ghcr.io/jhu-sheridan-libraries/idc-isle-dc/activemq:upstream-20200824-f8d1e8e-23-g9fe79fc
           name: activemq
           imagePullPolicy: Always
           resources:

--- a/base/alpaca_deployment.yaml
+++ b/base/alpaca_deployment.yaml
@@ -15,7 +15,7 @@ spec:
         app: alpaca
     spec:
       containers:
-      - image: ghcr.io/jhu-sheridan-libraries/idc-isle-dc/alpaca:upstream-20200824-f8d1e8e-19-g35fa7d2
+      - image: ghcr.io/jhu-sheridan-libraries/idc-isle-dc/alpaca:upstream-20200824-f8d1e8e-23-g9fe79fc
         name: alpaca
         imagePullPolicy: Always
         env:

--- a/base/cantaloupe_deployment.yaml
+++ b/base/cantaloupe_deployment.yaml
@@ -15,7 +15,7 @@ spec:
         app: cantaloupe
     spec:
       containers:
-        - image: islandora/cantaloupe:latest
+        - image: ghcr.io/jhu-sheridan-libraries/idc-isle-dc/cantaloupe:upstream-20200824-f8d1e8e-23-g9fe79fc
           name: cantaloupe
           imagePullPolicy: Always
           volumeMounts:

--- a/base/crayfits_deployment.yaml
+++ b/base/crayfits_deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
         - name: crayfits
-          image: ghcr.io/jhu-sheridan-libraries/idc-isle-dc/crayfits:upstream-20200824-f8d1e8e-14-g09641e3
+          image: ghcr.io/jhu-sheridan-libraries/idc-isle-dc/crayfits:upstream-20200824-f8d1e8e-23-g9fe79fc
           imagePullPolicy: Always
 

--- a/base/drupal_deployment.yaml
+++ b/base/drupal_deployment.yaml
@@ -39,7 +39,7 @@ spec:
 
       containers:
         - name: drupal
-          image: ghcr.io/jhu-library-operations/idc/drupal-static:upstream-20201007-739693ae-138-g55f4e3e   
+          image: ghcr.io/jhu-sheridan-libraries/idc-isle-dc/drupal-static:e6c3630
           #image: ghcr.io/jhu-library-operations/drupal-static:upstream-20201007-739693ae-123-g9a3a8e2
           imagePullPolicy: Always
           env:

--- a/base/fits_deployment.yaml
+++ b/base/fits_deployment.yaml
@@ -16,5 +16,5 @@ spec:
     spec:
       containers:
         - name: fits
-          image: ghcr.io/jhu-sheridan-libraries/idc-isle-dc/fits:upstream-20200824-f8d1e8e-19-g35fa7d2
+          image: ghcr.io/jhu-sheridan-libraries/idc-isle-dc/fits:upstream-20200824-f8d1e8e-23-g9fe79fc
 

--- a/base/homarus_deployment.yaml
+++ b/base/homarus_deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: homarus
-          image: ghcr.io/jhu-sheridan-libraries/idc-isle-dc/homarus:upstream-20200824-f8d1e8e-14-g09641e3
+          image: ghcr.io/jhu-sheridan-libraries/idc-isle-dc/homarus:upstream-20200824-f8d1e8e-23-g9fe79fc
           imagePullPolicy: Always
           env:
             - name: HOMARUS_JWT_PUBLIC_KEY

--- a/base/houdini_deployment.yaml
+++ b/base/houdini_deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: houdini
-          image: ghcr.io/jhu-sheridan-libraries/idc-isle-dc/houdini:upstream-20200824-f8d1e8e-19-g35fa7d2
+          image: ghcr.io/jhu-sheridan-libraries/idc-isle-dc/houdini:upstream-20200824-f8d1e8e-23-g9fe79fc
           env:
             - name: HOUDINI_JWT_PUBLIC_KEY
               value: |

--- a/base/hypercube_deployment.yaml
+++ b/base/hypercube_deployment.yaml
@@ -15,7 +15,7 @@ spec:
         app: hypercube
     spec:
       containers:
-      - image: ghcr.io/jhu-sheridan-libraries/idc-isle-dc/hypercube:upstream-20200824-f8d1e8e-14-g09641e3
+      - image: ghcr.io/jhu-sheridan-libraries/idc-isle-dc/hypercube:upstream-20200824-f8d1e8e-23-g9fe79fc
         name: hypercube
         env:
           - name: HYPERCUBE_JWT_PUBLIC_KEY

--- a/base/mariadb_deployment.yaml
+++ b/base/mariadb_deployment.yaml
@@ -15,7 +15,7 @@ spec:
         app: mariadb
     spec:
       containers:
-        - image: islandora/mariadb:latest
+        - image: ghcr.io/jhu-sheridan-libraries/idc-isle-dc/mariadb:upstream-20200824-f8d1e8e-23-g9fe79fc
           name: mariadb
           imagePullPolicy: Always
           volumeMounts:

--- a/base/solr_deployment.yaml
+++ b/base/solr_deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
 #      - image: ghcr.io/jhu-sheridan-libraries/idc-isle-dc/solr:upstream-20200824-f8d1e8e-14-g09641e3
-      - image: ghcr.io/jhu-library-operations/solr:upstream-20200824-f8d1e8e-19-g5c591a1.dirty
+      - image: ghcr.io/jhu-sheridan-libraries/idc-isle-dc/solr:upstream-20200824-f8d1e8e-23-g9fe79fc
         name: solr
         imagePullPolicy: Always
         volumeMounts:

--- a/overlays/development/linux/mariadb_pv.yaml
+++ b/overlays/development/linux/mariadb_pv.yaml
@@ -21,4 +21,4 @@ spec:
   capacity:
     storage: 1Gi
   hostPath:
-    path: /minikube-host/idc/mariadb-files
+    path: /minikube-host/idc/mariadb-dump

--- a/overlays/development/wsl2/mariadb_pv.yaml
+++ b/overlays/development/wsl2/mariadb_pv.yaml
@@ -30,5 +30,5 @@ spec:
   capacity:
     storage: 1Gi
   hostPath:
-    path: /run/desktop/mnt/host/c/kubernetes/idc/mariadb-files
+    path: /run/desktop/mnt/host/c/kubernetes/idc/mariadb-dump
     type: DirectoryOrCreate


### PR DESCRIPTION
* Uses latest buildkit and drupal-static images
* Adds a "quick start"  section to the documentation, detailing how to extract a snapshot from published images, and put it in the right place in order to start the environment
* Updates a path in the snapshot content to reflect latest snapshot format

## To test
* Follow the quick start instructions in the README.  In the end, all pods should be running.