### PR TITLE
Fix Alpaca configuration

### DIFF
--- a/base/alpaca_deployment.yaml
+++ b/base/alpaca_deployment.yaml
@@ -20,12 +20,16 @@ spec:
         imagePullPolicy: Always
         env:
           - name: ALPACA_ACTIVEMQ_URL
-            value: tcp://activemq-service:61613
+            value: tcp://activemq-service:61616
           - name: ALPACA_ACTIVEMQ_PASSWORD
             value: password
           - name: ALPACA_KARAF_ADMIN_PASSWORD
             value: password
           - name: ALPACA_FITS_SERVICE
             value: http://crayfits-service:8000/
+          - name: ALPACA_HOUDINI_SERVICE
+            value: http://houdini-service:8000/convert
           - name: ALPACA_HOMARUS_SERVICE
             value: http://homarus-service:8000/convert
+          - name: ALPACA_OCR_SERVICE
+            value: http://hypercube-service:8000


### PR DESCRIPTION
* Use openwire port for connecting karaf to activemq
  * Karaf was unable to connect to activeMQ using STOMP protocol; changing to the openwire port made it happy again
* Add additional microservice URIs

Derivatives still don't work, but this PR allows alpaca to consume from ActiveMQ queues, and configures the proper URI endpoints to Houdini and Tesseract microservices

## To Test
* Make sure recent snapshot content is placed in the expected location for your OS, and start the k8s stack
* Forward the 8161 port of the activemq container so you can log into its management console `kubectl port-forward --namespace windev $(kubectl get pods --namespace windev | grep activemq | awk '{print $1}') 8161:8161`
* With your browser, go to http://localhost:8161/admin  credentials are `admin:5Z43ohRq8JE6s4` Click on the `queues` tab.  You should see several islandora-* named queues.  (previously, before this fix, the list was empty)

Resolves #33