### PR TITLE
Add ENV Variables to increase timeouts

### DIFF
--- a/overlays/aws/definitions/test/kustomization.yaml
+++ b/overlays/aws/definitions/test/kustomization.yaml
@@ -27,4 +27,9 @@ patchesStrategicMerge:
   - patches/minio-deployment-patch.yaml
   - patches/homarus_php_max_execution_patch.yaml
   - patches/houdini_php_max_execution_patch.yaml
+  - patches/fits_php_max_execution_patch.yaml
+  - patches/crayfits_php_max_execution_patch.yaml
+  - patches/hypercube_php_max_execution_patch.yaml
+  - patches/alpaca_homerus_socket_timeout_patch.yaml
+  - patches/drupal_jwt_expiry_interval_patch.yaml
 namespace: test

--- a/overlays/aws/definitions/test/patches/alpaca_homerus_socket_timeout_patch.yaml
+++ b/overlays/aws/definitions/test/patches/alpaca_homerus_socket_timeout_patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alpaca
+spec:
+  template:
+    spec:
+      containers:
+        - name: alpaca
+          env:
+            - name: ALPACA_HOMERUS_HTTP_SOCKET_TIMEOUT_MS
+              value: "72000000"

--- a/overlays/aws/definitions/test/patches/crayfits_php_max_execution_patch.yaml
+++ b/overlays/aws/definitions/test/patches/crayfits_php_max_execution_patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: crayfits
+spec:
+  template:
+    spec:
+      containers:
+        - name: crayfits
+          env:
+            - name: PHP_MAX_EXECUTION_TIME
+              value: "7200"

--- a/overlays/aws/definitions/test/patches/drupal_jwt_expiry_interval_patch.yaml
+++ b/overlays/aws/definitions/test/patches/drupal_jwt_expiry_interval_patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: drupal
+spec:
+  template:
+    spec:
+      containers:
+        - name: drupal
+          env:
+            - name: DRUPAL_JWT_EXPIRY_INTERVAL
+              value: '+4 hour'

--- a/overlays/aws/definitions/test/patches/fits_php_max_execution_patch.yaml
+++ b/overlays/aws/definitions/test/patches/fits_php_max_execution_patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fits
+spec:
+  template:
+    spec:
+      containers:
+        - name: fits
+          env:
+            - name: PHP_MAX_EXECUTION_TIME
+              value: "7200"

--- a/overlays/aws/definitions/test/patches/hypercube_php_max_execution_patch.yaml
+++ b/overlays/aws/definitions/test/patches/hypercube_php_max_execution_patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hypercube
+spec:
+  template:
+    spec:
+      containers:
+        - name: hypercube
+          env:
+            - name: PHP_MAX_EXECUTION_TIME
+              value: "7200"


### PR DESCRIPTION
This sets:
PHP_MAX_EXECUTION_TIME to 2 hours in the micro services in alpaca
ALPACA_HOMERUS_HTTP_SOCKET_TIMEOUT_MS to 2 hours in alpaca
DRUPAL_JWT_EXPIRY_INTERVAL to "+4 hours" in drupal

this partially fixes jhu-idc/idcApp-k8s/#59