### PR TITLE
Fixing PHP_MAX_EXECUTION_TIME in drupal

### DIFF
--- a/overlays/aws/definitions/test/kustomization.yaml
+++ b/overlays/aws/definitions/test/kustomization.yaml
@@ -15,6 +15,7 @@ patchesStrategicMerge:
   - patches/drupal-service-patch.yaml
   - patches/drupal.namespace-config-patch.yaml
   - patches/drupal.sp-patch.yaml
+  - patches/drupal_php_max_execution_patch.yaml
   - patches/image-updates-patch.yaml
   - patches/mariadb-deployment-replica-patch.yaml
   - patches/reverseproxy-service-ssl-patch.yaml
@@ -26,7 +27,6 @@ patchesStrategicMerge:
   - patches/shared-shared-db.rootUser-patch.yaml
   - patches/minio-deployment-patch.yaml
   - patches/homarus_php_max_execution_patch.yaml
-  - patches/houdini_php_max_execution_patch.yaml
   - patches/fits_php_max_execution_patch.yaml
   - patches/crayfits_php_max_execution_patch.yaml
   - patches/hypercube_php_max_execution_patch.yaml

--- a/overlays/aws/definitions/test/patches/drupal_php_max_execution_patch.yaml
+++ b/overlays/aws/definitions/test/patches/drupal_php_max_execution_patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: drupal
+spec:
+  template:
+    spec:
+      containers:
+        - name: drupal
+          env:
+            - name: PHP_MAX_EXECUTION_TIME
+              value: "300"


### PR DESCRIPTION
This removes the PHP_MAX_EXECUTION_TIME from the houdini and adds it to DRUPAL instead.