### PR TITLE
Added environment variable PHP_FPM_MAX_CHILDREN

### DIFF
--- a/base/drupal_deployment.yaml
+++ b/base/drupal_deployment.yaml
@@ -213,6 +213,11 @@ spec:
                 secretKeyRef:
                   name: drupal
                   key: root_password
+            - name: PHP_FPM_MAX_CHILDREN
+              valueFrom:
+                configMapKeyRef:
+                  name: shared
+                  key: drupal.fpm_max_children
 # End: Drupal Secrets
 # Begin: SMTP Settings
             - name: DRUPAL_SMTP_ENABLE

--- a/base/shared_configmap.yaml
+++ b/base/shared_configmap.yaml
@@ -60,6 +60,9 @@ data:
 #  drupal.default.db.password: In secrets
 ### End Old Stuff to be removed
 
+# Drupal configuration
+  drupal.fpm_max_children: "10"
+
 
 # SAML Configuration options
   drupal.sp.assertionallowedclockskew: "180"


### PR DESCRIPTION
Resolves jhu-idc/idc-general/issues/438

Creates an entry in the shared config map
Uses that entry as an environment variable to drupal to set PHP_FPM_MAX_CHILDREN