### PR TITLE
Separate PHP_MAX_EXECUTION_TIMEOUT into nginx variables

### DIFF
--- a/base/activemq_deployment.yaml
+++ b/base/activemq_deployment.yaml
@@ -15,7 +15,7 @@ spec:
         app: activemq
     spec:
       containers:
-        - image: ghcr.io/jhu-idc/activemq:v0.2.0
+        - image: ghcr.io/jhu-idc/activemq:v0.3.0
           name: activemq
           imagePullPolicy: Always
           resources:

--- a/base/alpaca_deployment.yaml
+++ b/base/alpaca_deployment.yaml
@@ -15,7 +15,7 @@ spec:
         app: alpaca
     spec:
       containers:
-      - image: ghcr.io/jhu-idc/alpaca:v0.2.0
+      - image: ghcr.io/jhu-idc/alpaca:v0.3.0
         name: alpaca
         imagePullPolicy: Always
         resources:
@@ -38,7 +38,7 @@ spec:
         #   initialDelaySeconds: 20
         env:
           - name: ALPACA_HOMERUS_HTTP_SOCKET_TIMEOUT_MS
-            value: "7200000"
+            value: "7200"
           - name: ALPACA_ACTIVEMQ_URL
             value: tcp://activemq-service:61616
           - name: ALPACA_ACTIVEMQ_PASSWORD

--- a/base/cantaloupe_deployment.yaml
+++ b/base/cantaloupe_deployment.yaml
@@ -15,7 +15,7 @@ spec:
         app: cantaloupe
     spec:
       containers:
-        - image: ghcr.io/jhu-idc/cantaloupe:v0.2.0
+        - image: ghcr.io/jhu-idc/cantaloupe:v0.3.0
           name: cantaloupe
           imagePullPolicy: Always
           readinessProbe:

--- a/base/crayfits_deployment.yaml
+++ b/base/crayfits_deployment.yaml
@@ -16,11 +16,31 @@ spec:
     spec:
       containers:
         - name: crayfits
-          image: ghcr.io/jhu-idc/crayfits:v0.2.0
+          image: ghcr.io/jhu-idc/crayfits:v0.3.0
           imagePullPolicy: Always
           env:
             - name: PHP_MAX_EXECUTION_TIME
               value: "7200"
+            - name: NGINX_FASTCGI_READ_TIMEOUT
+              value: "7200" 
+            - name: NGINX_FASTCGI_SEND_TIMEOUT
+              value: "7200" 
+            - name: NGINX_FASTCGI_CONNECT_TIMEOUT
+              value: "7200" 
+            - name: NGINX_PROXY_READ_TIMEOUT
+              value: "7200" 
+            - name: NGINX_PROXY_SEND_TIMEOUT
+              value: "7200" 
+            - name: NGINX_PROXY_CONNECT_TIMEOUT
+              value: "7200" 
+            - name: NGINX_SEND_TIMEOUT
+              value: "3600" 
+            - name: NGINX_KEEPALIVE_TIMEOUT
+              value: "7200" 
+            - name: NGINX_CLIENT_BODY_TIMEOUT
+              value: "7200" 
+            - name: NGINX_LINGERING_TIMEOUT
+              value: "7200" 
           readinessProbe:
             httpGet:
               path: /

--- a/base/drupal_deployment.yaml
+++ b/base/drupal_deployment.yaml
@@ -79,7 +79,7 @@ spec:
             initialDelaySeconds: 60
             periodSeconds: 10
             failureThreshold: 5            
-          image: ghcr.io/jhu-idc/drupal-static:v0.2.0
+          image: ghcr.io/jhu-idc/drupal-static:v0.3.0
           resources:
             requests:
               memory: 200Mi
@@ -88,6 +88,26 @@ spec:
           imagePullPolicy: Always
           env:
             - name: PHP_MAX_EXECUTION_TIME
+              value: "300"
+            - name: NGINX_FASTCGI_READ_TIMEOUT
+              value: "300" 
+            - name: NGINX_FASTCGI_SEND_TIMEOUT
+              value: "300" 
+            - name: NGINX_FASTCGI_CONNECT_TIMEOUT
+              value: "300" 
+            - name: NGINX_PROXY_READ_TIMEOUT
+              value: "300" 
+            - name: NGINX_PROXY_SEND_TIMEOUT
+              value: "300" 
+            - name: NGINX_PROXY_CONNECT_TIMEOUT
+              value: "300" 
+            - name: NGINX_SEND_TIMEOUT
+              value: "300" 
+            - name: NGINX_KEEPALIVE_TIMEOUT
+              value: "300" 
+            - name: NGINX_CLIENT_BODY_TIMEOUT
+              value: "300" 
+            - name: NGINX_LINGERING_TIMEOUT
               value: "300"
             - name: DRUPAL_DB_ROOT_USER
               valueFrom:

--- a/base/fits_deployment.yaml
+++ b/base/fits_deployment.yaml
@@ -20,6 +20,26 @@ spec:
           env:
             - name: PHP_MAX_EXECUTION_TIME
               value: "7200"
+            - name: NGINX_FASTCGI_READ_TIMEOUT
+              value: "7200" 
+            - name: NGINX_FASTCGI_SEND_TIMEOUT
+              value: "7200" 
+            - name: NGINX_FASTCGI_CONNECT_TIMEOUT
+              value: "7200" 
+            - name: NGINX_PROXY_READ_TIMEOUT
+              value: "7200" 
+            - name: NGINX_PROXY_SEND_TIMEOUT
+              value: "7200" 
+            - name: NGINX_PROXY_CONNECT_TIMEOUT
+              value: "7200" 
+            - name: NGINX_SEND_TIMEOUT
+              value: "3600" 
+            - name: NGINX_KEEPALIVE_TIMEOUT
+              value: "7200" 
+            - name: NGINX_CLIENT_BODY_TIMEOUT
+              value: "7200" 
+            - name: NGINX_LINGERING_TIMEOUT
+              value: "7200"            
           readinessProbe:
             httpGet:
               path: /fits/

--- a/base/homarus_deployment.yaml
+++ b/base/homarus_deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: homarus
-          image: ghcr.io/jhu-idc/homarus:v0.2.0
+          image: ghcr.io/jhu-idc/homarus:v0.3.0
           imagePullPolicy: Always
           
           readinessProbe:
@@ -43,4 +43,24 @@ spec:
             - name: HOMARUS_JWT_ADMIN_TOKEN
               value: islandora
             - name: PHP_MAX_EXECUTION_TIME
+              value: "7200"
+            - name: NGINX_FASTCGI_READ_TIMEOUT
+              value: "7200" 
+            - name: NGINX_FASTCGI_SEND_TIMEOUT
+              value: "7200" 
+            - name: NGINX_FASTCGI_CONNECT_TIMEOUT
+              value: "7200" 
+            - name: NGINX_PROXY_READ_TIMEOUT
+              value: "7200" 
+            - name: NGINX_PROXY_SEND_TIMEOUT
+              value: "7200" 
+            - name: NGINX_PROXY_CONNECT_TIMEOUT
+              value: "7200" 
+            - name: NGINX_SEND_TIMEOUT
+              value: "3600" 
+            - name: NGINX_KEEPALIVE_TIMEOUT
+              value: "7200" 
+            - name: NGINX_CLIENT_BODY_TIMEOUT
+              value: "7200" 
+            - name: NGINX_LINGERING_TIMEOUT
               value: "7200"

--- a/base/houdini_deployment.yaml
+++ b/base/houdini_deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: houdini
-          image: ghcr.io/jhu-idc/houdini:v0.2.0
+          image: ghcr.io/jhu-idc/houdini:v0.3.0
           readinessProbe:
             tcpSocket:
               port: 8000
@@ -35,6 +35,26 @@ spec:
           env:
             - name: PHP_MAX_EXECUTION_TIME
               value: "7200"
+            - name: NGINX_FASTCGI_READ_TIMEOUT
+              value: "7200" 
+            - name: NGINX_FASTCGI_SEND_TIMEOUT
+              value: "7200" 
+            - name: NGINX_FASTCGI_CONNECT_TIMEOUT
+              value: "7200" 
+            - name: NGINX_PROXY_READ_TIMEOUT
+              value: "7200" 
+            - name: NGINX_PROXY_SEND_TIMEOUT
+              value: "7200" 
+            - name: NGINX_PROXY_CONNECT_TIMEOUT
+              value: "7200" 
+            - name: NGINX_SEND_TIMEOUT
+              value: "3600" 
+            - name: NGINX_KEEPALIVE_TIMEOUT
+              value: "7200" 
+            - name: NGINX_CLIENT_BODY_TIMEOUT
+              value: "7200" 
+            - name: NGINX_LINGERING_TIMEOUT
+              value: "7200"              
             - name: HOUDINI_JWT_PUBLIC_KEY
               valueFrom:
                 secretKeyRef:

--- a/base/hypercube_deployment.yaml
+++ b/base/hypercube_deployment.yaml
@@ -15,7 +15,7 @@ spec:
         app: hypercube
     spec:
       containers:
-      - image: ghcr.io/jhu-idc/hypercube:v0.2.0
+      - image: ghcr.io/jhu-idc/hypercube:v0.3.0
         name: hypercube
         readinessProbe:
           tcpSocket:
@@ -35,6 +35,26 @@ spec:
         env:
           - name: PHP_MAX_EXECUTION_TIME
             value: "7200"
+          - name: NGINX_FASTCGI_READ_TIMEOUT
+            value: "7200" 
+          - name: NGINX_FASTCGI_SEND_TIMEOUT
+            value: "7200" 
+          - name: NGINX_FASTCGI_CONNECT_TIMEOUT
+            value: "7200" 
+          - name: NGINX_PROXY_READ_TIMEOUT
+            value: "7200" 
+          - name: NGINX_PROXY_SEND_TIMEOUT
+            value: "7200" 
+          - name: NGINX_PROXY_CONNECT_TIMEOUT
+            value: "7200" 
+          - name: NGINX_SEND_TIMEOUT
+            value: "3600" 
+          - name: NGINX_KEEPALIVE_TIMEOUT
+            value: "7200" 
+          - name: NGINX_CLIENT_BODY_TIMEOUT
+            value: "7200" 
+          - name: NGINX_LINGERING_TIMEOUT
+            value: "7200"            
           - name: HYPERCUBE_JWT_PUBLIC_KEY
             valueFrom:
               secretKeyRef:

--- a/base/mariadb_deployment.yaml
+++ b/base/mariadb_deployment.yaml
@@ -15,7 +15,7 @@ spec:
         app: mariadb
     spec:
       containers:
-        - image: ghcr.io/jhu-idc/mariadb:v0.2.0
+        - image: ghcr.io/jhu-idc/mariadb:v0.3.0
           name: mariadb
           imagePullPolicy: Always
           volumeMounts:

--- a/base/solr_deployment.yaml
+++ b/base/solr_deployment.yaml
@@ -15,7 +15,7 @@ spec:
         app: solr
     spec:
       containers:
-      - image: ghcr.io/jhu-idc/solr:v0.2.0
+      - image: ghcr.io/jhu-idc/solr:v0.3.0
         name: solr
         imagePullPolicy: Always
         readinessProbe:

--- a/overlays/aws/definitions/test/patches/image-updates-patch.yaml
+++ b/overlays/aws/definitions/test/patches/image-updates-patch.yaml
@@ -53,24 +53,24 @@
 #       containers:
 #         - name: crayfits
 #           image: ghcr.io/jhu-sheridan-libraries/idc-isle-dc/crayfits:upstream-20200824-f8d1e8e-27-g6cd914d
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
- name: drupal
- labels:
-   app: drupal
-spec:
- template:
-   spec:
-     containers:
-        - name: drupal
-          image: ghcr.io/jhu-sheridan-libraries/idc-isle-dc/drupal-static:v0.2.0-1-g321e9c6
-          resources:
-            requests:
-              memory: 4096Mi
-            limits:
-              memory: 4096Mi
+# ---
+# apiVersion: apps/v1
+# kind: Deployment
+# metadata:
+#  name: drupal
+#  labels:
+#    app: drupal
+# spec:
+#  template:
+#    spec:
+#      containers:
+#         - name: drupal
+#           image: ghcr.io/jhu-sheridan-libraries/idc-isle-dc/drupal-static:v0.2.0-1-g321e9c6
+#           resources:
+#             requests:
+#               memory: 4096Mi
+#             limits:
+#               memory: 4096Mi
 # ---
 # apiVersion: apps/v1
 # kind: Deployment


### PR DESCRIPTION
Separate PHP_MAX_EXECUTION_TIMEOUT into nginx variables, and update image tags to v0.3.0 to allow for the nginx vars to be used.
Fixes #96