### PR TITLE
bump drupal and reverseproxy timeouts per

### DIFF
--- a/base/drupal_deployment.yaml
+++ b/base/drupal_deployment.yaml
@@ -88,9 +88,9 @@ spec:
           imagePullPolicy: Always
           env:
             - name: PHP_MAX_EXECUTION_TIME
-              value: "300"
+              value: "450"
             - name: NGINX_FASTCGI_READ_TIMEOUT
-              value: "300" 
+              value: "450" 
             - name: NGINX_FASTCGI_SEND_TIMEOUT
               value: "300" 
             - name: NGINX_FASTCGI_CONNECT_TIMEOUT

--- a/overlays/aws/base/reverseproxy-configmap.yaml
+++ b/overlays/aws/base/reverseproxy-configmap.yaml
@@ -591,8 +591,8 @@ data:
       AllowEncodedSlashes On
       ProxyPreserveHost on
       RequestHeader set X-Forwarded-Proto "https"
-      ProxyPass "/cantaloupe/" "http://cantaloupe-service:8080/cantaloupe/" nocanon connectiontimeout=300 timeout=400
-      ProxyPass "/" "http://drupal-service/" connectiontimeout=300 timeout=400
+      ProxyPass "/cantaloupe/" "http://cantaloupe-service:8080/cantaloupe/" nocanon connectiontimeout=450 timeout=550
+      ProxyPass "/" "http://drupal-service/" connectiontimeout=450 timeout=550
 
 
     </VirtualHost>


### PR DESCRIPTION
https://github.com/jhu-idc/iDC-general/issues/443